### PR TITLE
#7 #342 提交实验7 通过拍照或相册获取图片实现用户头像更换

### DIFF
--- a/students/soft1714080902205/app/src/main/AndroidManifest.xml
+++ b/students/soft1714080902205/app/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
     <!-- 添加网络访问权限 -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- 声明访问sd卡权限 -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- 声明照相机权限 -->
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="true"
@@ -13,7 +18,13 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar"
         android:usesCleartextTraffic="true">
-        <activity android:name=".getimage.ImageShow"></activity>
+        <activity android:name=".person.HeadActivity"></activity>
+        <activity android:name=".photo.PhoneActivity" />
+        <activity android:name=".bookstore.BookWebActivity" />
+        <activity android:name=".note.Write_Main" />
+        <activity android:name=".note.AddNoteActivity" />
+        <activity android:name=".note.UpdateOrReadActivity" />
+        <activity android:name=".getimage.ImageShow" />
         <activity android:name=".booksinfo.BookMian" />
         <activity android:name=".NewActivity" />
         <activity android:name=".Soft1714080902205Activity_bottom" />
@@ -36,7 +47,16 @@
         </activity> <!-- 应用自身bug，添加解决 -->
         <uses-library
             android:name="org.apache.http.legacy"
-            android:required="false" />
+            android:required="false" /> <!-- 注册照相机功能相关内容 -->
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="edu.hzuapps.androidlabs.soft1714080902205.person.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/students/soft1714080902205/app/src/main/java/edu/hzuapps/androidlabs/soft1714080902205/person/HeadActivity.java
+++ b/students/soft1714080902205/app/src/main/java/edu/hzuapps/androidlabs/soft1714080902205/person/HeadActivity.java
@@ -1,0 +1,260 @@
+package edu.hzuapps.androidlabs.soft1714080902205.person;
+
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.support.annotation.NonNull;
+import android.support.v4.content.FileProvider;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import edu.hzuapps.androidlabs.soft1714080902205.R;
+import edu.hzuapps.androidlabs.soft1714080902205.Soft1714080902205Activity;
+import pub.devrel.easypermissions.AppSettingsDialog;
+import pub.devrel.easypermissions.EasyPermissions;
+
+public class HeadActivity extends AppCompatActivity implements EasyPermissions.PermissionCallbacks{
+
+    private Context mContext;
+    private AlertDialog profilePictureDialog;
+    private static final String PERMISSION_CAMERA = Manifest.permission.CAMERA;
+    private static final String PERMISSION_WRITE = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+    private static final int REQUEST_PERMISSION_CAMERA = 0x001;
+    private static final int REQUEST_PERMISSION_WRITE = 0x002;
+    private static final int CROP_REQUEST_CODE = 0x003;
+
+    private ImageView ivAvatar;
+
+    /**
+     * 文件相关
+     */
+    private File captureFile;
+    private File rootFile;
+    private File cropFile;
+
+    private String path;
+    private String filepath;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        setContentView(R.layout.head_activity);
+        super.onCreate(savedInstanceState);
+        ivAvatar = findViewById(R.id.iv_avatar);
+
+        //加载Activity时读取sdcard的图片
+        path=Environment.getExternalStorageDirectory().getAbsolutePath() + "/TakePhotoPic";
+        filepath=path+"/avatar.jpg";
+        File file=new File(filepath);
+        if(file.exists()){
+            Bitmap bm=BitmapFactory.decodeFile(filepath);
+            ivAvatar.setImageBitmap(bm);
+        }else{
+            Toast.makeText(HeadActivity.this,"未成功读取图片",Toast.LENGTH_SHORT).show();
+        }
+
+
+        mContext = this;
+
+
+
+        rootFile = new File(MyConstant.PIC_PATH);
+        if (!rootFile.exists()) {
+            rootFile.mkdirs();
+        }
+
+        Button btn_return=(Button)findViewById(R.id.btn_return);
+        btn_return.setOnClickListener(new View.OnClickListener(){
+
+            public void onClick(View v) {
+                Intent intent = new Intent(HeadActivity.this, Soft1714080902205Activity.class);
+                startActivity(intent);
+            }
+        });
+    }
+
+    public void btnClick(View view) {
+
+        if (profilePictureDialog == null) {
+            @SuppressLint("InflateParams") View rootView = LayoutInflater.from(this).inflate(R.layout.item_profile_picture, null);
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            rootView.findViewById(R.id.tv_take_photo).setOnClickListener(onTakePhotoListener);
+            rootView.findViewById(R.id.tv_choose_photo).setOnClickListener(onChoosePhotoListener);
+            builder.setView(rootView);
+            profilePictureDialog = builder.create();
+            profilePictureDialog.show();
+        } else {
+            profilePictureDialog.show();
+        }
+    }
+
+    private void dismissProfilePictureDialog() {
+        if (profilePictureDialog != null && profilePictureDialog.isShowing()) {
+            profilePictureDialog.dismiss();
+        }
+    }
+
+    private View.OnClickListener onTakePhotoListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            dismissProfilePictureDialog();
+            if (EasyPermissions.hasPermissions(mContext, PERMISSION_CAMERA, PERMISSION_WRITE)) {
+                takePhoto();
+            } else {
+                EasyPermissions.requestPermissions(HeadActivity.this, "need camera permission", REQUEST_PERMISSION_CAMERA, PERMISSION_CAMERA, PERMISSION_WRITE);
+            }
+        }
+    };
+
+    //拍照
+    private void takePhoto() {
+        //用于保存调用相机拍照后所生成的文件
+        if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+            return;
+        }
+        captureFile = new File(rootFile, "temp.jpg");
+        //跳转到调用系统相机
+        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        //判断版本 如果在Android7.0以上,使用FileProvider获取Uri
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            intent.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            Uri contentUri = FileProvider.getUriForFile(HeadActivity.this, "edu.hzuapps.androidlabs.soft1714080902205.person.fileprovider",captureFile);
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
+        } else {
+            //否则使用Uri.fromFile(file)方法获取Uri
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(captureFile));
+        }
+        startActivityForResult(intent, REQUEST_PERMISSION_CAMERA);
+    }
+
+    private View.OnClickListener onChoosePhotoListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            dismissProfilePictureDialog();
+            if (EasyPermissions.hasPermissions(mContext, PERMISSION_WRITE)) {
+                    choosePhoto();
+            } else {
+                EasyPermissions.requestPermissions(HeadActivity.this, "need camera permission", REQUEST_PERMISSION_WRITE, PERMISSION_WRITE);
+            }
+        }
+    };
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+    }
+
+
+    //从相册选择
+    private void choosePhoto() {
+        Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
+        photoPickerIntent.setType("image/*");
+        startActivityForResult(photoPickerIntent, REQUEST_PERMISSION_WRITE);
+    }
+
+    @Override
+    public void onPermissionsGranted(int requestCode, @NonNull List<String> perms) {
+        if (requestCode == REQUEST_PERMISSION_CAMERA) {
+            takePhoto();
+        } else if (requestCode == REQUEST_PERMISSION_WRITE) {
+            choosePhoto();
+        }
+    }
+
+    /**
+     * 裁剪图片
+     */
+    private void cropPhoto(Uri uri) {
+        cropFile = new File(rootFile, "avatar.jpg");
+        Intent intent = new Intent("com.android.camera.action.CROP");
+        intent.setDataAndType(uri, "image/*");
+        intent.putExtra("crop", "true");
+        intent.putExtra("aspectX", 1);
+        intent.putExtra("aspectY", 1);
+        intent.putExtra("outputX", 300);
+        intent.putExtra("outputY", 300);
+        intent.putExtra("return-data", false);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(cropFile));
+        intent.putExtra("outputFormat", Bitmap.CompressFormat.PNG.toString());
+        intent.putExtra("noFaceDetection", true);
+        intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivityForResult(intent, CROP_REQUEST_CODE);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == RESULT_OK) {
+            switch (requestCode) {
+                case REQUEST_PERMISSION_CAMERA:
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        Uri contentUri = FileProvider.getUriForFile(HeadActivity.this, "edu.hzuapps.androidlabs.soft1714080902205.person.fileprovider",captureFile);
+                        cropPhoto(contentUri);
+                    } else {
+                        cropPhoto(Uri.fromFile(captureFile));
+                    }
+                    break;
+                case REQUEST_PERMISSION_WRITE:
+                    cropPhoto(data.getData());
+                    break;
+                case CROP_REQUEST_CODE:
+                    saveImage(cropFile.getAbsolutePath());
+                    ivAvatar.setImageBitmap(BitmapFactory.decodeFile(cropFile.getAbsolutePath()));
+                    break;
+                default:
+                    break;
+            }
+        }
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+
+    /**
+     * @param path
+     * @return
+     */
+    public String saveImage(String path) {
+        if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+            return null;
+        }
+        Bitmap bitmap = BitmapFactory.decodeFile(path);
+        try {
+            FileOutputStream fos = new FileOutputStream(cropFile);
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos);
+            fos.flush();
+            fos.close();
+            return cropFile.getAbsolutePath();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+
+    @Override
+    public void onPermissionsDenied(int requestCode, @NonNull List<String> perms) {
+        if (EasyPermissions.somePermissionPermanentlyDenied(this, perms)) {
+            new AppSettingsDialog.Builder(this).build().show();
+        }
+    }
+}

--- a/students/soft1714080902205/app/src/main/java/edu/hzuapps/androidlabs/soft1714080902205/person/MyConstant.java
+++ b/students/soft1714080902205/app/src/main/java/edu/hzuapps/androidlabs/soft1714080902205/person/MyConstant.java
@@ -1,0 +1,9 @@
+package edu.hzuapps.androidlabs.soft1714080902205.person;
+
+import android.os.Environment;
+
+public class MyConstant {
+
+    public static final String PIC_PATH = Environment.getExternalStorageDirectory().getAbsolutePath() + "/TakePhotoPic";
+}
+

--- a/students/soft1714080902205/app/src/main/java/edu/hzuapps/androidlabs/soft1714080902205/person/TakePhotoApplication.java
+++ b/students/soft1714080902205/app/src/main/java/edu/hzuapps/androidlabs/soft1714080902205/person/TakePhotoApplication.java
@@ -1,0 +1,85 @@
+package edu.hzuapps.androidlabs.soft1714080902205.person;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.View;
+import android.widget.TextView;
+
+import edu.hzuapps.androidlabs.soft1714080902205.R;
+
+
+public class TakePhotoApplication extends Application {
+
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(final Activity activity, Bundle savedInstanceState) {
+                //这里全局给Activity设置toolbar和title,你想象力有多丰富,这里就有多强大,以前放到BaseActivity的操作都可以放到这里
+                if (activity.findViewById(R.id.toolbar) != null) {
+                    //找到 Toolbar 并且替换 Actionbar
+                    if (activity instanceof AppCompatActivity) {
+                        ((AppCompatActivity) activity).setSupportActionBar((Toolbar) activity.findViewById(R.id.toolbar));
+                        ((AppCompatActivity) activity).getSupportActionBar().setDisplayShowTitleEnabled(false);
+                        ((AppCompatActivity) activity).getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+                        ((Toolbar) activity.findViewById(R.id.toolbar)).setNavigationOnClickListener(new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                activity.finish();
+                            }
+                        });
+
+                    } else {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            activity.setActionBar((android.widget.Toolbar) activity.findViewById(R.id.toolbar));
+                            activity.getActionBar().setDisplayShowTitleEnabled(false);
+                        }
+                    }
+                }
+                if (activity.findViewById(R.id.toolbar_title) != null) {
+                    //找到 Toolbar 的标题栏并设置标题名
+                    ((TextView) activity.findViewById(R.id.toolbar_title)).setText(activity.getTitle());
+
+
+                }
+            }
+
+            @Override
+            public void onActivityStarted(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityResumed(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityPaused(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityStopped(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+
+            }
+
+            @Override
+            public void onActivityDestroyed(Activity activity) {
+
+            }
+        });
+
+    }
+}

--- a/students/soft1714080902205/app/src/main/res/layout/head_activity.xml
+++ b/students/soft1714080902205/app/src/main/res/layout/head_activity.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="edu.hzuapps.androidlabs.soft1714080902205.person.HeadActivity"
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar_layout"/>
+
+    <ImageView
+        android:id="@+id/iv_avatar"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:src="@drawable/ic_launch_loginpicture"
+        android:layout_gravity="center"/>
+
+    <Button
+        android:onClick="btnClick"
+        android:text="拍照或从相册选择"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+
+    <Button
+        android:id="@+id/btn_return"
+        android:text="确定并返回"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+
+</LinearLayout>

--- a/students/soft1714080902205/app/src/main/res/layout/item_profile_picture.xml
+++ b/students/soft1714080902205/app/src/main/res/layout/item_profile_picture.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+
+    <TextView
+        android:id="@+id/tv_take_photo"
+        android:gravity="center"
+        android:textSize="16sp"
+        android:padding="10dp"
+        android:text="拍照"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#e5e5e5"/>
+
+    <TextView
+        android:id="@+id/tv_choose_photo"
+        android:textSize="16sp"
+        android:padding="10dp"
+        android:gravity="center"
+        android:text="相册"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>
+<!--HeadActivity的button控件弹窗-->

--- a/students/soft1714080902205/app/src/main/res/layout/toolbar_layout.xml
+++ b/students/soft1714080902205/app/src/main/res/layout/toolbar_layout.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.Toolbar
+    android:id="@+id/toolbar"
+    android:background="@color/colorPrimary"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    tools:context=".person.HeadActivity"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+
+
+    <TextView
+        android:id="@+id/toolbar_title"
+        android:textSize="25sp"
+        android:textColor="@android:color/white"
+        tools:text="个人中心"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</android.support.v7.widget.Toolbar>
+<!--HeadActivity的toolbar-->

--- a/students/soft1714080902205/app/src/main/res/xml/file_paths.xml
+++ b/students/soft1714080902205/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Resource>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path path="." name="external_path" />
+</paths>
+</Resource>


### PR DESCRIPTION
该功能作为“个人中心”其中的头像更换：
由于android版本的提高，现在实现相机功能需要在AndroidManifest.xml里面声明权限还要配置provider
遇到问题的总结：
1.AndroidManifest.xml里的android:authorities要和HeadActivity.java里的FileProvider.getUriForFile一样
2.要声明相机权限和sd卡权限

运行截图：
1.点击第一个button控件：
![image](https://user-images.githubusercontent.com/48147493/56745049-3a337f00-67ac-11e9-96db-e5fbb050d50f.png)
2.选择拍照启动系统照相机：
![image](https://user-images.githubusercontent.com/48147493/56745087-4fa8a900-67ac-11e9-874c-4872201b5a22.png)
3.拍完启动截图功能：
![image](https://user-images.githubusercontent.com/48147493/56745146-67802d00-67ac-11e9-8409-4dac9e1ed5eb.png)
4.imageview控件图片更改：
![image](https://user-images.githubusercontent.com/48147493/56745208-854d9200-67ac-11e9-8048-fc41fdc62733.png)
5.再次点击第一个button，选择相册获取：
![image](https://user-images.githubusercontent.com/48147493/56745262-9bf3e900-67ac-11e9-9c6e-939e33e9d010.png)
6.选择图片：
![image](https://user-images.githubusercontent.com/48147493/56745289-a9a96e80-67ac-11e9-9e36-b7f65eae706b.png)
7.进行截图：
![image](https://user-images.githubusercontent.com/48147493/56745316-b4fc9a00-67ac-11e9-990c-8b667724c365.png)
8.截图完成imageview控件再次更改图片：
![image](https://user-images.githubusercontent.com/48147493/56745377-d5c4ef80-67ac-11e9-93d4-7fa01c9e7de9.png)
